### PR TITLE
Adds the default comment 

### DIFF
--- a/settings/language-nagios.cson
+++ b/settings/language-nagios.cson
@@ -1,0 +1,3 @@
+'.source.nagios':
+  'editor':
+    'commentStart': '# '


### PR DESCRIPTION
This adds the "#" as the default comment style instead of "*//*" since the java style comment is not used in Nagios config files.